### PR TITLE
Replace `before_filter` with `before_action`, which is the modern form

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 This module provides a class-level method for specifying that certain
 actions are guarded against being called without certain prerequisites
-being met. This is essentially a special kind of before_filter.
+being met. This is essentially a special kind of before_action.
 
 An action may be guarded against being invoked without certain request
 parameters being set, or without certain session values existing.

--- a/lib/action_controller/verification.rb
+++ b/lib/action_controller/verification.rb
@@ -6,7 +6,7 @@ module ActionController #:nodoc:
 
     # This module provides a class-level method for specifying that certain
     # actions are guarded against being called without certain prerequisites
-    # being met. This is essentially a special kind of before_filter.
+    # being met. This is essentially a special kind of before_action.
     #
     # An action may be guarded against being invoked without certain request
     # parameters being set, or without certain session values existing.
@@ -79,7 +79,7 @@ module ActionController #:nodoc:
       #   do not apply this verification to the actions specified in the associated
       #   array (may also be a single value).
       def verify(options={})
-        before_filter :only => options[:only], :except => options[:except] do
+        before_action :only => options[:only], :except => options[:except] do
           verify_action options
         end
       end

--- a/test/verification_test.rb
+++ b/test/verification_test.rb
@@ -29,7 +29,7 @@ class VerificationTestController < ActionController::Base
   verify :only => :guarded_by_not_xhr, :xhr => false,
          :redirect_to => { :action => "unguarded" }
 
-  before_filter :unconditional_redirect, :only => :two_redirects
+  before_action :unconditional_redirect, :only => :two_redirects
   verify :only => :two_redirects, :method => :post,
          :redirect_to => { :action => "unguarded" }
 


### PR DESCRIPTION
Let's not trigger deprecations whenever we load a class that calls `verify`